### PR TITLE
Feat/actions crawler

### DIFF
--- a/.ci/crawl.sh
+++ b/.ci/crawl.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+devp2p discv4 crawl -timeout "$ETH_DNS_DISCV4_CRAWLTIME" all.json
+
+git add all.json	
+
+ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
+git -c user.name="meows" -c user.email='b5c6@protonmail.com' commit --author 'crawler <>' -m "ci update (all.json) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
+        
+Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
+
+$ETH_DNS_DISCV4_KEY_PUBLICINFO"

--- a/.ci/crawl.sh
+++ b/.ci/crawl.sh
@@ -1,12 +1,3 @@
 #!/bin/sh
 
 devp2p discv4 crawl -timeout "$ETH_DNS_DISCV4_CRAWLTIME" all.json
-
-git add all.json	
-
-ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
-git -c user.name="meows" -c user.email='b5c6@protonmail.com' commit --author 'crawler <>' -m "ci update (all.json) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
-        
-Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
-
-$ETH_DNS_DISCV4_KEY_PUBLICINFO"

--- a/.ci/deploy.sh
+++ b/.ci/deploy.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -e
+
+proto_groups=(all les)
+
+for network in "$@"; do
+
+    echo "Deploy: $network"
+
+    for p in "${proto_groups[@]}"; do
+        echo -n "Deploy: ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+
+        # Ensure that we actually have a nodeset to deploy to DNS.
+        [[ ! -d ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN} ]] || [[ ! -f ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}/nodes.json ]] && { echo " | DNE, skipping"; continue; }
+
+        echo
+        devp2p dns to-cloudflare --zoneid "$ETH_DNS_CLOUDFLARE_ZONEID" "${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+    done
+done

--- a/.ci/deps.sh
+++ b/.ci/deps.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+set -e
+
+# Check programs we depend on.
+command -v devp2p >/dev/null 2>&1 && echo "OK: devp2p command in PATH" || { echo "Please install devp2p"; exit 1; }
+command -v ethkey >/dev/null 2>&1 && echo "OK: ethkey command in PATH" || { echo "Please install ethkey"; exit 1; }
+
+# Check that we have key and keypass file.
+if [ ! -f $ETH_DNS_DISCV4_KEY_PATH ] || [ ! -f $ETH_DNS_DISCV4_KEYPASS_PATH ]; then
+    echo "
+No key found at key file path or no password file found at ${ETH_DNS_DISCV4_KEYPASS_PATH}. 
+Use 'ethkey generate ${ETH_DNS_DISCV4_KEY_PATH}'
+Save the password in plaintext in ${ETH_DNS_DISCV4_KEYPASS_PATH}
+"
+    exit 1
+else
+    echo "OK: Key and password file exist."
+fi
+
+# Check that we have deploy variables set.
+if [ -z $CLOUDFLARE_API_TOKEN ]; then
+    echo "Missing CLOUDFLARE_API_TOKEN env var"
+    exit 1
+else
+    echo "OK: environment variable CLOUDFLARE_API_TOKEN is not empty."
+fi
+
+# I'm not sure why I couldn't get devp2p to work without using the --zoneid flag; kept getting 403 bad perms.
+# Using the flag seems to fix it, and this var gets set as the value for that flag.
+# It's associated with the specific domain name that Cloudflare is managing and that we want to deploy to.
+if [ -z $ETH_DNS_CLOUDFLARE_ZONEID ]; then
+    echo "Missing ETH_DNS_CLOUDFLARE_ZONEID env var"
+    exit 1
+else
+    echo "OK: environment variable ETH_DNS_CLOUDFLARE_ZONEID is not empty."
+fi
+

--- a/.ci/filter_and_sign.sh
+++ b/.ci/filter_and_sign.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+proto_groups=(all les)
+
+for network in "$@"; do
+
+    echo "Filter: $network"
+   
+    mkdir -p "all.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+    devp2p nodeset filter all.json -eth-network "$network" >"all.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}/nodes.json"
+
+    mkdir -p "les.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+    devp2p nodeset filter all.json -les-server -eth-network "$network" >"les.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}/nodes.json"
+
+    
+    echo "Sign: $network"
+
+    for p in "${proto_groups[@]}"; do
+        echo -n "Sign: ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+
+        # Ensure that we actually have a nodeset to sign.
+        [ ! -d ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN} ] || [ ! -f ${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}/nodes.json ] && { echo " | DNE, skipping"; continue; }
+
+        echo
+        cat "${ETH_DNS_DISCV4_KEYPASS_PATH}" | devp2p dns sign "${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}" "${ETH_DNS_DISCV4_KEY_PATH}" && echo "OK"
+
+        git add "${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
+    done
+
+    ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
+    git -c user.name="meows" -c user.email='b5c6@protonmail.com' commit --author "crawler <>" -m "ci update ($network) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
+        
+Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
+
+$ETH_DNS_DISCV4_KEY_PUBLICINFO"
+    
+done

--- a/.ci/filter_and_sign.sh
+++ b/.ci/filter_and_sign.sh
@@ -14,7 +14,7 @@ for network in "$@"; do
     mkdir -p "les.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
     devp2p nodeset filter all.json -les-server -eth-network "$network" >"les.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}/nodes.json"
 
-    
+
     echo "Sign: $network"
 
     for p in "${proto_groups[@]}"; do
@@ -26,14 +26,6 @@ for network in "$@"; do
         echo
         cat "${ETH_DNS_DISCV4_KEYPASS_PATH}" | devp2p dns sign "${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}" "${ETH_DNS_DISCV4_KEY_PATH}" && echo "OK"
 
-        git add "${p}.${network}.${ETH_DNS_DISCV4_PARENT_DOMAIN}"
     done
-
-    ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
-    git -c user.name="meows" -c user.email='b5c6@protonmail.com' commit --author "crawler <>" -m "ci update ($network) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER
-        
-Crawltime: $ETH_DNS_DISCV4_CRAWLTIME
-
-$ETH_DNS_DISCV4_KEY_PUBLICINFO"
     
 done

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -4,18 +4,19 @@ on:
     - cron: '0 */2 * * *'
 jobs:
   build:
-    if: github.repository == 'etclabscore/discv4-dns-lists'
+    if: github.repository == 'ethereum/discv4-dns-lists'
     name: Discv4-DNS-Crawler
     runs-on: ubuntu-latest
     env:
       ETH_DNS_DISCV4_CRAWLTIME: 30m
-      ETH_DNS_DISCV4_PARENT_DOMAIN: blockd.info
+      ETH_DNS_DISCV4_PARENT_DOMAIN: ethdisco.net
       ETH_DNS_DISCV4_KEY_PATH: ./secrets/dnskey.json
       ETH_DNS_DISCV4_KEYPASS_PATH: ./secrets/dnskey_password.txt
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       ETH_DNS_CLOUDFLARE_ZONEID: ${{ secrets.ETH_DNS_CLOUDFLARE_ZONEID }}
       ETH_DNS_DISCV4_KEY: ${{ secrets.ETH_DNS_DISCV4_KEY }}
       ETH_DNS_DISCV4_KEYPASS: ${{ secrets.ETH_DNS_DISCV4_KEYPASS }}
+
 
     steps:
     - name: Set up Go
@@ -28,30 +29,11 @@ jobs:
 
     - name: Check out code
       uses: actions/checkout@v2
-      with:
-        ref: etccore
-        token: ${{ secrets.PAT_REPO_MEOWSBITS }}
 
-    - uses: actions/checkout@v2
-      with:
-        ref: etccore
-        token: ${{ secrets.PAT_REPO_MEOWSBITS }}
-    - name: Checkout submodules
-      shell: bash
+    - name: Install dependencies
       run: |
-        # If your submodules are configured to use SSH instead of HTTPS please uncomment the following line
-        # git config --global url."https://github.com/".insteadOf "git@github.com:"
-        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
-        git submodule sync --recursive
-        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --depth=1
-        cd core-geth
-        git fetch origin --tags
-        latest_tag="$(git describe --abbrev=0)"
-        git checkout ${latest_tag}
-        make all
-        echo "::add-path::$(pwd)/build/bin"
-        cd ..
-        git diff --quiet || { git add core-geth && git -c user.name='meows' -c user.email='b5c6@protonmail.com' commit --author='crawler <>' -m "ci update (core-geth:${latest_tag}) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER"; }
+        go get -u github.com/ethereum/go-ethereum/cmd/devp2p
+        go get -u github.com/ethereum/go-ethereum/cmd/ethkey
 
     - name: Setup secrets
       run: |
@@ -62,8 +44,6 @@ jobs:
     - name: Check env and secrets
       run: |
         ./.ci/deps.sh
-        export ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
-        echo "$ETH_DNS_DISCV4_KEY_PUBLICINFO"
 
     - name: Crawl
       run: |
@@ -71,17 +51,21 @@ jobs:
 
     - name: Filter and sign
       run: |
-        ./.ci/filter_and_sign.sh classic kotti mordor
+        ./.ci/filter_and_sign.sh mainnet ropsten rinkeby goerli
+
+    - name: Commit and Push
+      env:
+        GITHUB_USER: FIXME
+        GITHUB_PAT: FIXME
+      run: |
+        git config --local user.name 'crawler'
+        git config --local user.email 'noreply@users.noreply.github.com'
+        git add all* les*
+        git commit --author 'crawler <>' -m "automatic update: crawl time ${ETH_DNS_DISCV4_CRAWLTIME} ci ${GITHUB_RUN_ID}:${GITHUB_RUN_NUMBER}"
+        git remote set-url origin https://${GITHUB_USER}:${GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git
+        git push origin master
 
     - name: Deploy to DNS
       run: |
-        ./.ci/deploy.sh classic kotti mordor
+        ./.ci/deploy.sh mainnet ropsten rinkeby goerli
 
-    - name: Push
-      env:
-        GITHUB_PAT: ${{ secrets.PAT_REPO_MEOWSBITS }}
-      run: |
-        git config --local user.name 'meows'
-        git config --local user.email 'b5c6@protonmail.com'
-        git remote set-url origin https://meowsbits:${GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git
-        git push origin etccore

--- a/.github/workflows/crawl.yml
+++ b/.github/workflows/crawl.yml
@@ -1,0 +1,87 @@
+name: Discv4 Crawl and DNS Update
+on:
+  schedule:
+    - cron: '0 */2 * * *'
+jobs:
+  build:
+    if: github.repository == 'etclabscore/discv4-dns-lists'
+    name: Discv4-DNS-Crawler
+    runs-on: ubuntu-latest
+    env:
+      ETH_DNS_DISCV4_CRAWLTIME: 30m
+      ETH_DNS_DISCV4_PARENT_DOMAIN: blockd.info
+      ETH_DNS_DISCV4_KEY_PATH: ./secrets/dnskey.json
+      ETH_DNS_DISCV4_KEYPASS_PATH: ./secrets/dnskey_password.txt
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      ETH_DNS_CLOUDFLARE_ZONEID: ${{ secrets.ETH_DNS_CLOUDFLARE_ZONEID }}
+      ETH_DNS_DISCV4_KEY: ${{ secrets.ETH_DNS_DISCV4_KEY }}
+      ETH_DNS_DISCV4_KEYPASS: ${{ secrets.ETH_DNS_DISCV4_KEYPASS }}
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2-beta
+      with:
+        go-version: 1.13.8
+      id: go
+
+    - run: go version
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        ref: etccore
+        token: ${{ secrets.PAT_REPO_MEOWSBITS }}
+
+    - uses: actions/checkout@v2
+      with:
+        ref: etccore
+        token: ${{ secrets.PAT_REPO_MEOWSBITS }}
+    - name: Checkout submodules
+      shell: bash
+      run: |
+        # If your submodules are configured to use SSH instead of HTTPS please uncomment the following line
+        # git config --global url."https://github.com/".insteadOf "git@github.com:"
+        auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+        git submodule sync --recursive
+        git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --depth=1
+        cd core-geth
+        git fetch origin --tags
+        latest_tag="$(git describe --abbrev=0)"
+        git checkout ${latest_tag}
+        make all
+        echo "::add-path::$(pwd)/build/bin"
+        cd ..
+        git diff --quiet || { git add core-geth && git -c user.name='meows' -c user.email='b5c6@protonmail.com' commit --author='crawler <>' -m "ci update (core-geth:${latest_tag}) $GITHUB_RUN_ID:$GITHUB_RUN_NUMBER"; }
+
+    - name: Setup secrets
+      run: |
+        mkdir secrets
+        echo "$ETH_DNS_DISCV4_KEY" > "$ETH_DNS_DISCV4_KEY_PATH"
+        echo "$ETH_DNS_DISCV4_KEYPASS" > "$ETH_DNS_DISCV4_KEYPASS_PATH"
+
+    - name: Check env and secrets
+      run: |
+        ./.ci/deps.sh
+        export ETH_DNS_DISCV4_KEY_PUBLICINFO="$(cat $ETH_DNS_DISCV4_KEYPASS_PATH | ethkey inspect $ETH_DNS_DISCV4_KEY_PATH | grep -E '(Addr|Pub)')"
+        echo "$ETH_DNS_DISCV4_KEY_PUBLICINFO"
+
+    - name: Crawl
+      run: |
+        ./.ci/crawl.sh
+
+    - name: Filter and sign
+      run: |
+        ./.ci/filter_and_sign.sh classic kotti mordor
+
+    - name: Deploy to DNS
+      run: |
+        ./.ci/deploy.sh classic kotti mordor
+
+    - name: Push
+      env:
+        GITHUB_PAT: ${{ secrets.PAT_REPO_MEOWSBITS }}
+      run: |
+        git config --local user.name 'meows'
+        git config --local user.email 'b5c6@protonmail.com'
+        git remote set-url origin https://meowsbits:${GITHUB_PAT}@github.com/${GITHUB_REPOSITORY}.git
+        git push origin etccore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+secrets/


### PR DESCRIPTION
Hey, We're running a downstream iteration of this at https://github.com/etclabscore/discv4-dns-lists, and have the crawler running on [the Github Actions CI there](https://github.com/etclabscore/discv4-dns-lists/actions). This frees up a devops task and makes the provenance of the lists transparent.

Here's a start at adding the same functionality here if you're interested.

The config currently uses Actions' `schedule: cron` config with what I thought is a sufficient time span. There are other ways to handle this, but this seemed the simplest to me.

---

## TODO

### Repo Secrets

The Action config depends on a few Secrets being set at the Github repo level.
- [ ]  `CLOUDFLARE_API_TOKEN` 
- [ ]  `ETH_DNS_CLOUDFLARE_ZONEID` (This isn't necessary if you can get get the `devp2p to-xxx` to work without it.... I couldn't.) 
- [ ]  `ETH_DNS_DISCV4_KEY`: The full content of the signing key file, eg. `cat key.json | pbcopy` or whatever.
- [ ]  `ETH_DNS_DISCV4_KEYPASS`: The key's password.
- [ ]  maybe a `GITHUB_USER_PERSONAL_ACCESS_TOKEN` (PAT). If you can get the `git push` to work without explicit user authentication (see comment below) then you won't need this.
